### PR TITLE
feat: Rename GreetingsController to DashboardController

### DIFF
--- a/api/app/controllers/dashboard_controller.rb
+++ b/api/app/controllers/dashboard_controller.rb
@@ -1,8 +1,8 @@
-class GreetingsController < ApplicationController
-  # Since we're building an API, skip CSRF protection
+class DashboardController < ApplicationController
+  # Since we're building an API, we skip CSRF protection
   # protect_from_forgery with: :null_session
 
-  def hello
+  def links
     links = {
       app1: I18n.t('links.app1'),
       app2: I18n.t('links.app2'),
@@ -12,7 +12,7 @@ class GreetingsController < ApplicationController
       portfolio: I18n.t('links.portfolio'),
       blog: I18n.t('links.blog'),
       hub: I18n.t('links.hub'),
-      python_apps: I18n.t('links.python_apps'),
+      python: I18n.t('links.python'),
     }
 
     render json: {

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -40,4 +40,4 @@ en:
     portfolio: "Portfolio"
     blog: "Blog"
     hub: "Hub"
-    python_apps: "Python"
+    python: "Python"

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # Define a route for the hello action
-  get '/hello', to: 'greetings#hello'
+  get '/dashboard_links', to: 'dashboard#links'
 
   # For API-only applications, you might want to namespace your routes
   # namespace :api do

--- a/api/test/controllers/greetings_controller_test.rb
+++ b/api/test/controllers/greetings_controller_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-class GreetingsControllerTest < ActionDispatch::IntegrationTest
+class DashboardControllerTest < ActionDispatch::IntegrationTest
   test "should get hello" do
-    get greetings_hello_url
+    get dashboard_links_url
     assert_response :success
   end
 end

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,8 +20,8 @@ function App() {
   useEffect(() => {
     const fetchGreeting = async () => {
       try {
-        const response = await axios.get('/api/hello');
-        setLinks(response.data.links); // Expecting { app1: "App1", app2: "App2", ... }
+        const response = await axios.get('/api/dashboard_links');
+        setLinks(response.data.links);
       } catch (err) {
         setError('Error fetching links');
         console.error(err);
@@ -32,7 +32,7 @@ function App() {
   }, []);
 
   const toggleTiles = () => {
-    setShowTiles((prev) => !prev); // Toggle the state to show/hide tiles
+    setShowTiles((prev) => !prev);
   };
 
   const changeLanguage = (lang: string) => {


### PR DESCRIPTION
- Renamed GreetingsController to DashboardController to better reflect its purpose.
- Updated the route for the 'hello' action to '/api/dashboard_links'.
- Adjusted references in the codebase to use the new controller name.
- Maintained the functionality of serving links with internationalized labels