### PR TITLE
fix: update nginx proxy path for ChronoQuest image assets

### DIFF
--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -341,8 +341,8 @@ http {
       proxy_set_header Connection "Upgrade";
       proxy_set_header Host $host;
     }
-    location /api/images/ {
-      proxy_pass http://chronoquest-backend:5000/api/images/;
+    location /images/ {
+      proxy_pass http://chronoquest-backend:5000/images/;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
     }


### PR DESCRIPTION
- Changed location block from /api/images/ to /images/
- Updated proxy_pass to reflect new backend route
- Aligns with Express backend changes to serve images at /images